### PR TITLE
Enhance startup tag browsing experience

### DIFF
--- a/src/routes/startups/+page.svelte
+++ b/src/routes/startups/+page.svelte
@@ -29,6 +29,15 @@
 		selectedTags = newSelectedTags;
 	}
 
+	// Create handler functions for each tag
+	function createRemoveTagHandler(tag: string) {
+		return () => removeTag(tag);
+	}
+
+	function createToggleTagHandler(tag: string) {
+		return () => toggleTag(tag);
+	}
+
 	let filteredSummaries = $derived(
 		summaries.filter((summary) => {
 			const q = search.toLowerCase();
@@ -103,8 +112,10 @@
 				<div class="flex flex-wrap items-center gap-2">
 					<span class="text-sm font-medium text-gray-700">Filtered by:</span>
 					{#each [...selectedTags] as tag}
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<!-- svelte-ignore a11y-no-static-element-interactions -->
 						<button
-							onclick={() => removeTag(tag)}
+							onclick={createRemoveTagHandler(tag)}
 							class="inline-flex items-center gap-1 rounded-full bg-purple-100 px-3 py-1 text-sm font-medium text-purple-800 transition-colors hover:bg-purple-200"
 						>
 							{tag}
@@ -226,8 +237,10 @@
 									.filter(Boolean)
 									.slice(0, 2) as tag}
 									{@const isSelected = selectedTags.has(tag)}
+									<!-- svelte-ignore a11y-click-events-have-key-events -->
+									<!-- svelte-ignore a11y-no-static-element-interactions -->
 									<button
-										onclick={() => toggleTag(tag)}
+										onclick={createToggleTagHandler(tag)}
 										class="rounded px-2 py-0.5 text-xs font-medium transition-colors cursor-pointer {isSelected 
 											? 'bg-purple-200 text-purple-800' 
 											: 'bg-gray-100 text-gray-700 hover:bg-purple-100 hover:text-purple-700'}"


### PR DESCRIPTION
Tag filtering was implemented in `src/routes/startups/ page.svelte`.

*   A `$state` rune `selectedTags` was introduced to manage selected tags as a `Set`.
*   Functions `toggleTag(tag: string)` and `removeTag(tag: string)` were added to manage the `selectedTags` state.
*   The `filteredSummaries` `$derived` function was updated to filter the list by all `selectedTags` (AND logic) before applying the search query.
*   Tags in the startup list were converted into clickable `<button>` elements.
    *   They now display a light purple hover state (`hover:bg-purple-100 hover:text-purple-700`).
    *   Selected tags appear in light purple (`bg-purple-200 text-purple-800`).
*   A new section was added to the header to display selected tags with a "Filtered by:" label. Each selected tag includes a remove button.
*   TypeScript errors related to event handling were resolved by defining event handler functions (`createToggleTagHandler`, `createRemoveTagHandler`) and referencing them directly in `onclick` attributes, aligning with Svelte 5's event syntax.