### PR TITLE
Create VC chatbot for startup evaluation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and add your actual API key
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
 			"dependencies": {
 				"@google/genai": "^1.5.1",
 				"@libsql/client": "^0.14.0",
+				"@types/marked": "^5.0.2",
 				"@types/papaparse": "^5.3.16",
 				"dotenv": "^16.5.0",
 				"drizzle-orm": "^0.40.0",
+				"marked": "^15.0.12",
 				"papaparse": "^5.5.3",
 				"vite-node": "^3.2.3"
 			},
@@ -2129,6 +2131,12 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/marked": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz",
+			"integrity": "sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -4393,6 +4401,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
 	"dependencies": {
 		"@google/genai": "^1.5.1",
 		"@libsql/client": "^0.14.0",
+		"@types/marked": "^5.0.2",
 		"@types/papaparse": "^5.3.16",
 		"dotenv": "^16.5.0",
 		"drizzle-orm": "^0.40.0",
+		"marked": "^15.0.12",
 		"papaparse": "^5.5.3",
 		"vite-node": "^3.2.3"
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,8 +6,8 @@
 </script>
 
 <div class="min-h-screen bg-gray-50">
-	<!-- Modern Top Navigation -->
-	<nav class="bg-white shadow-sm border-b border-gray-200">
+	<!-- Fixed Top Navigation -->
+	<nav class="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm border-b border-gray-200">
 		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 			<div class="flex justify-between items-center h-16">
 				<!-- Logo/Brand -->
@@ -48,8 +48,8 @@
 		</div>
 	</nav>
 
-	<!-- Main Content -->
-	<main class="flex-1">
+	<!-- Main Content with top padding to account for fixed nav -->
+	<main class="pt-16">
 		{@render children()}
 	</main>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -37,6 +37,12 @@
 					>
 						Browse Startups
 					</a>
+					<a
+						href="/validation"
+						class="text-gray-700 hover:text-indigo-600 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 {$page.url.pathname === '/validation' ? 'text-indigo-600 bg-indigo-50' : ''}"
+					>
+						VC Validation
+					</a>
 				</div>
 			</div>
 		</div>

--- a/src/routes/validation/+page.svelte
+++ b/src/routes/validation/+page.svelte
@@ -1,5 +1,21 @@
 <script lang="ts">
 	import Button from '$lib/components/Button.svelte';
+	import { marked } from 'marked';
+	import { onMount } from 'svelte';
+
+	// Type definitions
+	interface Message {
+		type: 'vc' | 'user';
+		content: string;
+	}
+
+	interface MemoData {
+		id: string;
+		timestamp: string;
+		conversation: Message[];
+		memo: string;
+		title: string;
+	}
 
 	// VC Questions - exactly 20 as specified
 	const VC_QUESTIONS = [
@@ -27,21 +43,72 @@
 
 	// Chat state
 	let currentQuestionIndex = $state(0);
-	let messages = $state([]);
+	let messages = $state<Message[]>([]);
 	let userInput = $state('');
 	let isComplete = $state(false);
 	let isGeneratingMemo = $state(false);
 	let generatedMemo = $state('');
+	
+	// Historical memos state
+	let historicalMemos = $state<MemoData[]>([]);
+	let selectedMemo = $state<MemoData | null>(null);
+	let showSidebar = $state(true);
 
 	// Initialize with first question
 	$effect(() => {
-		if (messages.length === 0) {
+		if (messages.length === 0 && !selectedMemo) {
 			messages = [{
 				type: 'vc',
 				content: `Hello! I'm a VC partner and I'd like to understand your startup idea. I have 20 questions that will help us both evaluate the potential of your business. Let's start:\n\n${VC_QUESTIONS[0]}`
 			}];
 		}
 	});
+
+	// Load historical memos from localStorage
+	onMount(() => {
+		loadHistoricalMemos();
+	});
+
+	function loadHistoricalMemos() {
+		const memos: MemoData[] = [];
+		for (let i = 0; i < localStorage.length; i++) {
+			const key = localStorage.key(i);
+			if (key?.startsWith('vc-session-')) {
+				try {
+					const data = JSON.parse(localStorage.getItem(key) || '');
+					memos.push({
+						id: key,
+						...data
+					});
+				} catch (e) {
+					console.error('Error parsing memo:', e);
+				}
+			}
+		}
+		// Sort by timestamp, newest first
+		historicalMemos = memos.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+	}
+
+	function startNewSession() {
+		selectedMemo = null;
+		currentQuestionIndex = 0;
+		messages = [{
+			type: 'vc',
+			content: `Hello! I'm a VC partner and I'd like to understand your startup idea. I have 20 questions that will help us both evaluate the potential of your business. Let's start:\n\n${VC_QUESTIONS[0]}`
+		}];
+		userInput = '';
+		isComplete = false;
+		isGeneratingMemo = false;
+		generatedMemo = '';
+	}
+
+	function selectMemo(memo: MemoData) {
+		selectedMemo = memo;
+		// Reset chat state when viewing historical memo
+		isComplete = true;
+		generatedMemo = memo.memo;
+		messages = memo.conversation || [];
+	}
 
 	function sendMessage() {
 		if (!userInput.trim()) return;
@@ -154,7 +221,7 @@ Here is the conversation:
 
 ${conversationContext}
 
-Please format this as a professional startup evaluation memo that a VC would present to their investment committee.`;
+Please format this as a professional startup evaluation memo that a VC would present to their investment committee. Use markdown formatting for headers, lists, and emphasis.`;
 
 			const response = await fetch('/api/grounding', {
 				method: 'POST',
@@ -176,29 +243,44 @@ Please format this as a professional startup evaluation memo that a VC would pre
 			const memoData = {
 				timestamp: new Date().toISOString(),
 				conversation: messages,
-				memo: generatedMemo
+				memo: generatedMemo,
+				title: extractTitleFromMemo(generatedMemo)
 			};
 			
 			localStorage.setItem(`vc-session-${Date.now()}`, JSON.stringify(memoData));
 			
-			// Show completion message
-			messages = [...messages, {
-				type: 'vc',
-				content: "Perfect! I've generated your startup memo and saved it for future reference. You can view it below."
-			}];
+			// Reload historical memos
+			loadHistoricalMemos();
 
 		} catch (error) {
 			console.error('Error generating memo:', error);
-			messages = [...messages, {
-				type: 'vc',
-				content: "I apologize, but there was an error generating your startup memo. Please try again later."
-			}];
+			generatedMemo = "**Error generating memo**\n\nI apologize, but there was an error generating your startup memo. Please try again later.";
 		} finally {
 			isGeneratingMemo = false;
 		}
 	}
 
-	function handleKeydown(event) {
+	function extractTitleFromMemo(memo: string): string {
+		// Try to extract the first heading or use first line
+		const lines = memo.split('\n');
+		for (const line of lines) {
+			if (line.trim().startsWith('#')) {
+				return line.replace(/^#+\s*/, '').trim();
+			}
+		}
+		return `Session ${new Date().toLocaleDateString()}`;
+	}
+
+	function formatDate(timestamp: string): string {
+		return new Date(timestamp).toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'Enter' && !event.shiftKey) {
 			event.preventDefault();
 			sendMessage();
@@ -206,117 +288,237 @@ Please format this as a professional startup evaluation memo that a VC would pre
 	}
 
 	// Auto scroll to bottom when new messages arrive
-	let messagesContainer;
+	let messagesContainer: HTMLDivElement;
 	$effect(() => {
-		if (messagesContainer && messages.length > 0) {
+		if (messagesContainer && messages.length > 0 && !isComplete) {
 			setTimeout(() => {
 				messagesContainer.scrollTop = messagesContainer.scrollHeight;
 			}, 100);
 		}
 	});
+
+	// Convert markdown to HTML
+	function renderMarkdown(text: string): string {
+		try {
+			const result = marked(text);
+			// Handle both sync and async returns from marked
+			if (typeof result === 'string') {
+				return result;
+			} else {
+				// If it's a Promise, return the original text for now
+				console.warn('Marked returned a Promise, using original text');
+				return text;
+			}
+		} catch (e) {
+			console.error('Error rendering markdown:', e);
+			return text;
+		}
+	}
 </script>
 
-<div class="min-h-screen bg-gray-50 py-8">
-	<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-		<div class="bg-white rounded-xl shadow-lg overflow-hidden">
-			<!-- Header -->
-			<div class="bg-indigo-600 px-6 py-4">
+<!-- Fixed Layout Structure -->
+<div class="h-screen bg-gray-50 flex flex-col">
+	<!-- Fixed Header -->
+	<div class="bg-indigo-600 px-6 py-4 flex-shrink-0">
+		<div class="flex items-center justify-between">
+			<div>
 				<h1 class="text-2xl font-bold text-white">VC Validation Session</h1>
 				<p class="text-indigo-100 mt-1">
-					{#if !isComplete}
+					{#if selectedMemo}
+						Historical Session - {formatDate(selectedMemo.timestamp)}
+					{:else if !isComplete}
 						Question {currentQuestionIndex + 1} of {VC_QUESTIONS.length}
+					{:else if generatedMemo}
+						Session Complete - Memo Generated
 					{:else}
 						Session Complete
 					{/if}
 				</p>
 			</div>
-
-			<!-- Progress Bar -->
-			{#if !isComplete}
-				<div class="bg-gray-200 h-2">
-					<div 
-						class="bg-indigo-600 h-2 transition-all duration-300" 
-						style="width: {((currentQuestionIndex + 1) / VC_QUESTIONS.length) * 100}%"
-					></div>
-				</div>
-			{/if}
-
-			<!-- Messages Container -->
-			<div 
-				bind:this={messagesContainer}
-				class="h-96 overflow-y-auto p-6 space-y-4"
-			>
-				{#each messages as message, index (index)}
-					<div class="flex {message.type === 'user' ? 'justify-end' : 'justify-start'}">
-						<div class="max-w-3xl {message.type === 'user' 
-							? 'bg-indigo-600 text-white' 
-							: 'bg-gray-100 text-gray-900'} rounded-lg px-4 py-3">
-							<div class="text-sm font-medium mb-1">
-								{message.type === 'user' ? 'You' : 'VC Partner'}
-							</div>
-							<div class="whitespace-pre-wrap">{message.content}</div>
-						</div>
-					</div>
-				{/each}
-
-				{#if isGeneratingMemo}
-					<div class="flex justify-start">
-						<div class="bg-gray-100 text-gray-900 rounded-lg px-4 py-3">
-							<div class="text-sm font-medium mb-1">VC Partner</div>
-							<div class="flex items-center space-x-2">
-								<div class="animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-600"></div>
-								<span>Generating your startup memo...</span>
-							</div>
-						</div>
-					</div>
+			<div class="flex items-center space-x-4">
+				{#if selectedMemo || (isComplete && generatedMemo)}
+					<Button onclick={startNewSession} variant="secondary">
+						{#snippet children()}New Session{/snippet}
+					</Button>
 				{/if}
+				<button 
+					onclick={() => showSidebar = !showSidebar}
+					class="text-white hover:text-indigo-200 transition-colors"
+				>
+					<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+					</svg>
+				</button>
 			</div>
-
-			<!-- Input Area -->
-			{#if !isComplete}
-				<div class="border-t bg-gray-50 p-6">
-					<div class="flex flex-col space-y-4">
-						<!-- Text Input -->
-						<div class="flex space-x-3">
-							<textarea
-								bind:value={userInput}
-								onkeydown={handleKeydown}
-								placeholder="Type your answer here..."
-								class="flex-1 border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none"
-								rows="3"
-							></textarea>
-							<Button onclick={sendMessage} disabled={!userInput.trim()}>
-								{#snippet children()}Send{/snippet}
-							</Button>
-						</div>
-
-						<!-- Action Buttons -->
-						<div class="flex space-x-3">
-							<Button variant="outline" onclick={handleDontKnow}>
-								{#snippet children()}I Don't Know{/snippet}
-							</Button>
-							<Button variant="outline" onclick={handleHelpWithResearch}>
-								{#snippet children()}Help with Research{/snippet}
-							</Button>
-						</div>
-					</div>
-				</div>
-			{/if}
 		</div>
 
-		<!-- Generated Memo Display -->
-		{#if generatedMemo}
-			<div class="mt-8 bg-white rounded-xl shadow-lg overflow-hidden">
-				<div class="bg-green-600 px-6 py-4">
-					<h2 class="text-2xl font-bold text-white">Generated Startup Memo</h2>
-					<p class="text-green-100 mt-1">Professional investment evaluation based on your session</p>
-				</div>
-				<div class="p-6">
-					<div class="prose max-w-none">
-						<pre class="whitespace-pre-wrap font-sans text-gray-900 leading-relaxed">{generatedMemo}</pre>
-					</div>
-				</div>
+		<!-- Progress Bar -->
+		{#if !isComplete && !selectedMemo}
+			<div class="bg-indigo-700 h-2 rounded-full mt-4">
+				<div 
+					class="bg-white h-2 rounded-full transition-all duration-300" 
+					style="width: {((currentQuestionIndex + 1) / VC_QUESTIONS.length) * 100}%"
+				></div>
 			</div>
 		{/if}
 	</div>
+
+	<!-- Main Content Area -->
+	<div class="flex-1 flex overflow-hidden">
+		<!-- Sidebar for Historical Memos -->
+		{#if showSidebar}
+			<div class="w-80 bg-white border-r border-gray-200 flex flex-col">
+				<div class="p-4 border-b border-gray-200">
+					<h2 class="text-lg font-semibold text-gray-900">Historical Memos</h2>
+				</div>
+				<div class="flex-1 overflow-y-auto">
+					{#if historicalMemos.length === 0}
+						<div class="p-4 text-gray-500 text-sm">
+							No previous sessions yet. Complete a session to see your memos here.
+						</div>
+					{:else}
+						{#each historicalMemos as memo}
+							<button
+								onclick={() => selectMemo(memo)}
+								class="w-full p-4 text-left border-b border-gray-100 hover:bg-gray-50 transition-colors {selectedMemo?.id === memo.id ? 'bg-indigo-50 border-indigo-200' : ''}"
+							>
+								<div class="font-medium text-gray-900 text-sm truncate">
+									{memo.title || 'Untitled Session'}
+								</div>
+								<div class="text-xs text-gray-500 mt-1">
+									{formatDate(memo.timestamp)}
+								</div>
+							</button>
+						{/each}
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		<!-- Main Content -->
+		<div class="flex-1 flex flex-col">
+			{#if generatedMemo}
+				<!-- Memo Display -->
+				<div class="flex-1 overflow-y-auto">
+					<div class="max-w-4xl mx-auto p-6">
+						<div class="bg-white rounded-xl shadow-lg overflow-hidden">
+							<div class="bg-green-600 px-6 py-4">
+								<h2 class="text-2xl font-bold text-white">Startup Evaluation Memo</h2>
+								<p class="text-green-100 mt-1">Professional investment analysis</p>
+							</div>
+							<div class="p-8">
+								<div class="prose prose-lg max-w-none">
+									{@html renderMarkdown(generatedMemo)}
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			{:else}
+				<!-- Chat Interface -->
+				<div class="flex-1 flex flex-col">
+					<!-- Messages Container -->
+					<div 
+						bind:this={messagesContainer}
+						class="flex-1 overflow-y-auto p-6 space-y-4"
+					>
+						{#each messages as message, index (index)}
+							<div class="flex {message.type === 'user' ? 'justify-end' : 'justify-start'}">
+								<div class="max-w-3xl {message.type === 'user' 
+									? 'bg-indigo-600 text-white' 
+									: 'bg-gray-100 text-gray-900'} rounded-lg px-4 py-3">
+									<div class="text-sm font-medium mb-1">
+										{message.type === 'user' ? 'You' : 'VC Partner'}
+									</div>
+									<div class="whitespace-pre-wrap">{message.content}</div>
+								</div>
+							</div>
+						{/each}
+
+						{#if isGeneratingMemo}
+							<div class="flex justify-start">
+								<div class="bg-gray-100 text-gray-900 rounded-lg px-4 py-3">
+									<div class="text-sm font-medium mb-1">VC Partner</div>
+									<div class="flex items-center space-x-2">
+										<div class="animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-600"></div>
+										<span>Generating your startup memo...</span>
+									</div>
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<!-- Input Area -->
+					{#if !isComplete}
+						<div class="border-t bg-gray-50 p-6 flex-shrink-0">
+							<div class="flex flex-col space-y-4">
+								<!-- Text Input -->
+								<div class="flex space-x-3">
+									<textarea
+										bind:value={userInput}
+										onkeydown={handleKeydown}
+										placeholder="Type your answer here..."
+										class="flex-1 border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none"
+										rows="3"
+									></textarea>
+									<Button onclick={sendMessage} disabled={!userInput.trim()}>
+										{#snippet children()}Send{/snippet}
+									</Button>
+								</div>
+
+								<!-- Action Buttons -->
+								<div class="flex space-x-3">
+									<Button variant="outline" onclick={handleDontKnow}>
+										{#snippet children()}I Don't Know{/snippet}
+									</Button>
+									<Button variant="outline" onclick={handleHelpWithResearch}>
+										{#snippet children()}Help with Research{/snippet}
+									</Button>
+								</div>
+							</div>
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
 </div>
+
+<style>
+	/* Custom prose styles for better memo formatting */
+	:global(.prose h1) {
+		@apply text-3xl font-bold text-gray-900 mb-6 pb-2 border-b-2 border-gray-200;
+	}
+	
+	:global(.prose h2) {
+		@apply text-2xl font-semibold text-gray-800 mt-8 mb-4;
+	}
+	
+	:global(.prose h3) {
+		@apply text-xl font-semibold text-gray-700 mt-6 mb-3;
+	}
+	
+	:global(.prose p) {
+		@apply text-gray-700 leading-relaxed mb-4;
+	}
+	
+	:global(.prose ul) {
+		@apply space-y-2 mb-4;
+	}
+	
+	:global(.prose li) {
+		@apply text-gray-700;
+	}
+	
+	:global(.prose strong) {
+		@apply font-semibold text-gray-900;
+	}
+	
+	:global(.prose em) {
+		@apply italic text-gray-800;
+	}
+	
+	:global(.prose blockquote) {
+		@apply border-l-4 border-indigo-500 pl-4 italic text-gray-600 my-4;
+	}
+</style>

--- a/src/routes/validation/+page.svelte
+++ b/src/routes/validation/+page.svelte
@@ -323,68 +323,16 @@ Please format this as a professional startup evaluation memo that a VC would pre
 
 <!-- Main Container with proper spacing like other pages -->
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-	<!-- Page Header -->
-	<div class="mb-8">
-		<div class="flex items-center justify-between">
-			<div>
-				<h1 class="text-2xl font-bold text-gray-900">VC Validation Session</h1>
-				<p class="mt-1 text-gray-600">
-					{#if selectedMemo}
-						Historical Session - {formatDate(selectedMemo.timestamp)}
-					{:else if !isComplete}
-						Answer 20 key questions to validate your startup idea
-					{:else if generatedMemo}
-						Professional startup memo generated
-					{:else}
-						Session Complete
-					{/if}
-				</p>
-			</div>
-			<div class="flex items-center space-x-4">
-				{#if selectedMemo || (isComplete && generatedMemo)}
-					<Button onclick={startNewSession} variant="secondary">
-						{#snippet children()}New Session{/snippet}
-					</Button>
-				{/if}
-				<button 
-					onclick={() => showSidebar = !showSidebar}
-					class="rounded-lg bg-gray-100 p-2 text-gray-600 hover:bg-gray-200 hover:text-gray-900 transition-colors"
-					title="Toggle sidebar"
-				>
-					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-					</svg>
-				</button>
-			</div>
-		</div>
-
-		<!-- Progress Bar - only show during active chat -->
-		{#if isActiveChatMode}
-			<div class="mt-4">
-				<div class="flex items-center justify-between text-sm text-gray-600 mb-2">
-					<span>Progress</span>
-					<span>Question {currentQuestionIndex + 1} of {VC_QUESTIONS.length}</span>
-				</div>
-				<div class="bg-gray-200 h-2 rounded-full">
-					<div 
-						class="bg-indigo-600 h-2 rounded-full transition-all duration-300" 
-						style="width: {((currentQuestionIndex + 1) / VC_QUESTIONS.length) * 100}%"
-					></div>
-				</div>
-			</div>
-		{/if}
-	</div>
-
 	<!-- Main Content Layout -->
-	<div class="flex gap-8">
+	<div class="flex gap-8 h-[calc(100vh-8rem)]">
 		<!-- Sidebar for Historical Memos -->
 		{#if showSidebar}
 			<div class="w-80 flex-shrink-0">
-				<div class="bg-white rounded-lg border border-gray-200 shadow-sm">
+				<div class="bg-white rounded-lg border border-gray-200 shadow-sm h-full">
 					<div class="p-4 border-b border-gray-200">
 						<h2 class="text-lg font-semibold text-gray-900">Historical Memos</h2>
 					</div>
-					<div class="max-h-96 overflow-y-auto">
+					<div class="overflow-y-auto" style="height: calc(100% - 4rem);">
 						{#if historicalMemos.length === 0}
 							<div class="p-4 text-gray-500 text-sm">
 								No previous sessions yet. Complete a session to see your memos here.
@@ -410,15 +358,31 @@ Please format this as a professional startup evaluation memo that a VC would pre
 		{/if}
 
 		<!-- Main Content Area -->
-		<div class="flex-1">
+		<div class="flex-1 min-w-0">
 			{#if generatedMemo}
 				<!-- Memo Display -->
-				<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
-					<div class="bg-green-600 px-6 py-4">
-						<h2 class="text-xl font-bold text-white">Startup Evaluation Memo</h2>
-						<p class="text-green-100 mt-1">Professional investment analysis</p>
+				<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden h-full flex flex-col">
+					<div class="bg-green-600 px-6 py-4 flex items-center justify-between">
+						<div>
+							<h2 class="text-xl font-bold text-white">Startup Evaluation Memo</h2>
+							<p class="text-green-100 mt-1">Professional investment analysis</p>
+						</div>
+						<div class="flex items-center space-x-3">
+							<Button onclick={startNewSession} variant="secondary" size="sm">
+								{#snippet children()}New Session{/snippet}
+							</Button>
+							<button 
+								onclick={() => showSidebar = !showSidebar}
+								class="rounded-lg bg-green-700 p-2 text-green-100 hover:bg-green-800 hover:text-white transition-colors"
+								title="Toggle sidebar"
+							>
+								<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+								</svg>
+							</button>
+						</div>
 					</div>
-					<div class="p-8">
+					<div class="flex-1 overflow-y-auto p-8">
 						<div class="prose max-w-none">
 							{@html renderMarkdown(generatedMemo)}
 						</div>
@@ -426,7 +390,7 @@ Please format this as a professional startup evaluation memo that a VC would pre
 				</div>
 			{:else if messages.length === 0 && historicalMemos.length > 0}
 				<!-- Welcome state with historical memos -->
-				<div class="bg-white rounded-lg border border-gray-200 shadow-sm p-8 text-center">
+				<div class="bg-white rounded-lg border border-gray-200 shadow-sm p-8 text-center h-full flex flex-col justify-center">
 					<div class="mb-6">
 						<div class="mx-auto w-16 h-16 bg-indigo-100 rounded-full flex items-center justify-center mb-4">
 							<svg class="w-8 h-8 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -444,16 +408,45 @@ Please format this as a professional startup evaluation memo that a VC would pre
 				</div>
 			{:else}
 				<!-- Chat Interface -->
-				<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
-					<div class="bg-indigo-600 px-6 py-4">
-						<h2 class="text-xl font-bold text-white">VC Partner Discussion</h2>
-						<p class="text-indigo-100 mt-1">Professional startup evaluation session</p>
+				<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden h-full flex flex-col">
+					<div class="bg-indigo-600 px-6 py-4 flex-shrink-0">
+						<div class="flex items-center justify-between">
+							<div class="flex-1">
+								<h2 class="text-xl font-bold text-white">VC Partner Discussion</h2>
+								<p class="text-indigo-100 mt-1">Professional startup evaluation session</p>
+							</div>
+							<button 
+								onclick={() => showSidebar = !showSidebar}
+								class="rounded-lg bg-indigo-700 p-2 text-indigo-100 hover:bg-indigo-800 hover:text-white transition-colors ml-4"
+								title="Toggle sidebar"
+							>
+								<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+								</svg>
+							</button>
+						</div>
+						
+						<!-- Progress Bar in header -->
+						{#if isActiveChatMode}
+							<div class="mt-3">
+								<div class="flex items-center justify-between text-sm text-indigo-200 mb-2">
+									<span>Progress</span>
+									<span>Question {currentQuestionIndex + 1} of {VC_QUESTIONS.length}</span>
+								</div>
+								<div class="bg-indigo-700 h-2 rounded-full">
+									<div 
+										class="bg-white h-2 rounded-full transition-all duration-300" 
+										style="width: {((currentQuestionIndex + 1) / VC_QUESTIONS.length) * 100}%"
+									></div>
+								</div>
+							</div>
+						{/if}
 					</div>
 					
 					<!-- Messages Container -->
 					<div 
 						bind:this={messagesContainer}
-						class="h-96 overflow-y-auto p-6 space-y-4"
+						class="flex-1 overflow-y-auto p-6 space-y-4"
 					>
 						{#each messages as message, index (index)}
 							<div class="flex {message.type === 'user' ? 'justify-end' : 'justify-start'}">
@@ -483,7 +476,7 @@ Please format this as a professional startup evaluation memo that a VC would pre
 
 					<!-- Input Area -->
 					{#if !isComplete}
-						<div class="border-t bg-gray-50 p-6">
+						<div class="border-t bg-gray-50 p-6 flex-shrink-0">
 							<div class="flex flex-col space-y-4">
 								<!-- Text Input -->
 								<div class="flex space-x-3">

--- a/src/routes/validation/+page.svelte
+++ b/src/routes/validation/+page.svelte
@@ -407,7 +407,7 @@ Please format this as a professional startup evaluation memo that a VC would pre
 								<p class="text-green-100 mt-1">Professional investment analysis</p>
 							</div>
 							<div class="p-8">
-								<div class="prose prose-lg max-w-none">
+								<div class="prose max-w-none">
 									{@html renderMarkdown(generatedMemo)}
 								</div>
 							</div>
@@ -487,38 +487,60 @@ Please format this as a professional startup evaluation memo that a VC would pre
 <style>
 	/* Custom prose styles for better memo formatting */
 	:global(.prose h1) {
-		@apply text-3xl font-bold text-gray-900 mb-6 pb-2 border-b-2 border-gray-200;
+		font-size: 1.875rem;
+		font-weight: bold;
+		color: #111827;
+		margin-bottom: 1.5rem;
+		padding-bottom: 0.5rem;
+		border-bottom: 2px solid #e5e7eb;
 	}
 	
 	:global(.prose h2) {
-		@apply text-2xl font-semibold text-gray-800 mt-8 mb-4;
+		font-size: 1.5rem;
+		font-weight: 600;
+		color: #1f2937;
+		margin-top: 2rem;
+		margin-bottom: 1rem;
 	}
 	
 	:global(.prose h3) {
-		@apply text-xl font-semibold text-gray-700 mt-6 mb-3;
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: #374151;
+		margin-top: 1.5rem;
+		margin-bottom: 0.75rem;
 	}
 	
 	:global(.prose p) {
-		@apply text-gray-700 leading-relaxed mb-4;
+		color: #374151;
+		line-height: 1.625;
+		margin-bottom: 1rem;
 	}
 	
 	:global(.prose ul) {
-		@apply space-y-2 mb-4;
+		margin-bottom: 1rem;
 	}
 	
 	:global(.prose li) {
-		@apply text-gray-700;
+		color: #374151;
+		margin-bottom: 0.5rem;
 	}
 	
 	:global(.prose strong) {
-		@apply font-semibold text-gray-900;
+		font-weight: 600;
+		color: #111827;
 	}
 	
 	:global(.prose em) {
-		@apply italic text-gray-800;
+		font-style: italic;
+		color: #1f2937;
 	}
 	
 	:global(.prose blockquote) {
-		@apply border-l-4 border-indigo-500 pl-4 italic text-gray-600 my-4;
+		border-left: 4px solid #6366f1;
+		padding-left: 1rem;
+		font-style: italic;
+		color: #4b5563;
+		margin: 1rem 0;
 	}
 </style>

--- a/src/routes/validation/+page.svelte
+++ b/src/routes/validation/+page.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+	import Button from '$lib/components/Button.svelte';
+
+	// VC Questions - exactly 20 as specified
+	const VC_QUESTIONS = [
+		"What is the problem you are solving?",
+		"Who is the target customer?",
+		"Why is this problem urgent or important for them?",
+		"How are they solving it today?",
+		"What makes your solution better or different?",
+		"What is your product or service concept?",
+		"Will customers pay to solve this problem?",
+		"How much do you think they would pay?",
+		"How many customers exist (TAM)?",
+		"Is this a one-time, subscription, or usage-based model?",
+		"What is your estimated customer acquisition cost (CAC)?",
+		"What channels would you use to acquire customers?",
+		"Who are the main competitors or alternatives?",
+		"What's your moat or defensibility?",
+		"Why is now the right time to build this?",
+		"What is the fastest way to test or prototype this?",
+		"What Fidelity assets give us an advantage (data, brand, relationships, etc.)?",
+		"Are there internal dependencies or blockers inside Fidelity?",
+		"Does this align with Fidelity's strategy and brand?",
+		"Could this realistically be a $100M+ business?"
+	];
+
+	// Chat state
+	let currentQuestionIndex = $state(0);
+	let messages = $state([]);
+	let userInput = $state('');
+	let isComplete = $state(false);
+	let isGeneratingMemo = $state(false);
+	let generatedMemo = $state('');
+
+	// Initialize with first question
+	$effect(() => {
+		if (messages.length === 0) {
+			messages = [{
+				type: 'vc',
+				content: `Hello! I'm a VC partner and I'd like to understand your startup idea. I have 20 questions that will help us both evaluate the potential of your business. Let's start:\n\n${VC_QUESTIONS[0]}`
+			}];
+		}
+	});
+
+	function sendMessage() {
+		if (!userInput.trim()) return;
+
+		// Add user message
+		messages = [...messages, {
+			type: 'user',
+			content: userInput.trim()
+		}];
+
+		// Move to next question or finish
+		currentQuestionIndex++;
+		
+		if (currentQuestionIndex < VC_QUESTIONS.length) {
+			// Add next VC question
+			setTimeout(() => {
+				messages = [...messages, {
+					type: 'vc',
+					content: VC_QUESTIONS[currentQuestionIndex]
+				}];
+			}, 500);
+		} else {
+			// All questions done
+			isComplete = true;
+			setTimeout(() => {
+				messages = [...messages, {
+					type: 'vc',
+					content: "Excellent! That completes our evaluation session. I'm now generating a comprehensive startup memo based on our conversation..."
+				}];
+				generateStartupMemo();
+			}, 500);
+		}
+
+		userInput = '';
+	}
+
+	function handleDontKnow() {
+		messages = [...messages, {
+			type: 'user',
+			content: "I don't know"
+		}];
+
+		currentQuestionIndex++;
+		
+		if (currentQuestionIndex < VC_QUESTIONS.length) {
+			setTimeout(() => {
+				messages = [...messages, {
+					type: 'vc',
+					content: `That's okay. Let's move on to the next question:\n\n${VC_QUESTIONS[currentQuestionIndex]}`
+				}];
+			}, 500);
+		} else {
+			isComplete = true;
+			setTimeout(() => {
+				messages = [...messages, {
+					type: 'vc',
+					content: "That completes our evaluation session. I'm now generating a comprehensive startup memo based on our conversation..."
+				}];
+				generateStartupMemo();
+			}, 500);
+		}
+	}
+
+	function handleHelpWithResearch() {
+		messages = [...messages, {
+			type: 'user',
+			content: "Help with Research"
+		}];
+
+		setTimeout(() => {
+			messages = [...messages, {
+				type: 'vc',
+				content: `I understand you'd like help researching this aspect. For now, let's continue with what you know and we can revisit this during the memo generation. Moving to the next question:\n\n${VC_QUESTIONS[currentQuestionIndex + 1] || "That was our final question."}`
+			}];
+		}, 500);
+
+		currentQuestionIndex++;
+		
+		if (currentQuestionIndex >= VC_QUESTIONS.length) {
+			isComplete = true;
+			setTimeout(() => {
+				generateStartupMemo();
+			}, 1000);
+		}
+	}
+
+	async function generateStartupMemo() {
+		isGeneratingMemo = true;
+		
+		try {
+			// Bundle the conversation for the grounding endpoint
+			const conversationContext = messages
+				.map((msg, index) => `${msg.type === 'vc' ? 'VC' : 'Entrepreneur'}: ${msg.content}`)
+				.join('\n\n');
+
+			const prompt = `Based on the following VC evaluation session with an entrepreneur, generate a comprehensive 2-page startup memo that outlines the business described. The memo should be professional, analytical, and follow standard VC memo format with sections for:
+
+1. Executive Summary
+2. Problem & Opportunity
+3. Solution & Product
+4. Market & Competition
+5. Business Model
+6. Go-to-Market Strategy
+7. Team & Execution
+8. Financial Projections
+9. Risks & Mitigation
+10. Investment Recommendation
+
+Here is the conversation:
+
+${conversationContext}
+
+Please format this as a professional startup evaluation memo that a VC would present to their investment committee.`;
+
+			const response = await fetch('/api/grounding', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ prompt })
+			});
+
+			const result = await response.json();
+			
+			if (result.error) {
+				throw new Error(result.error);
+			}
+
+			generatedMemo = result.text;
+			
+			// Save to localStorage for future reference
+			const memoData = {
+				timestamp: new Date().toISOString(),
+				conversation: messages,
+				memo: generatedMemo
+			};
+			
+			localStorage.setItem(`vc-session-${Date.now()}`, JSON.stringify(memoData));
+			
+			// Show completion message
+			messages = [...messages, {
+				type: 'vc',
+				content: "Perfect! I've generated your startup memo and saved it for future reference. You can view it below."
+			}];
+
+		} catch (error) {
+			console.error('Error generating memo:', error);
+			messages = [...messages, {
+				type: 'vc',
+				content: "I apologize, but there was an error generating your startup memo. Please try again later."
+			}];
+		} finally {
+			isGeneratingMemo = false;
+		}
+	}
+
+	function handleKeydown(event) {
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			sendMessage();
+		}
+	}
+
+	// Auto scroll to bottom when new messages arrive
+	let messagesContainer;
+	$effect(() => {
+		if (messagesContainer && messages.length > 0) {
+			setTimeout(() => {
+				messagesContainer.scrollTop = messagesContainer.scrollHeight;
+			}, 100);
+		}
+	});
+</script>
+
+<div class="min-h-screen bg-gray-50 py-8">
+	<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+		<div class="bg-white rounded-xl shadow-lg overflow-hidden">
+			<!-- Header -->
+			<div class="bg-indigo-600 px-6 py-4">
+				<h1 class="text-2xl font-bold text-white">VC Validation Session</h1>
+				<p class="text-indigo-100 mt-1">
+					{#if !isComplete}
+						Question {currentQuestionIndex + 1} of {VC_QUESTIONS.length}
+					{:else}
+						Session Complete
+					{/if}
+				</p>
+			</div>
+
+			<!-- Progress Bar -->
+			{#if !isComplete}
+				<div class="bg-gray-200 h-2">
+					<div 
+						class="bg-indigo-600 h-2 transition-all duration-300" 
+						style="width: {((currentQuestionIndex + 1) / VC_QUESTIONS.length) * 100}%"
+					></div>
+				</div>
+			{/if}
+
+			<!-- Messages Container -->
+			<div 
+				bind:this={messagesContainer}
+				class="h-96 overflow-y-auto p-6 space-y-4"
+			>
+				{#each messages as message, index (index)}
+					<div class="flex {message.type === 'user' ? 'justify-end' : 'justify-start'}">
+						<div class="max-w-3xl {message.type === 'user' 
+							? 'bg-indigo-600 text-white' 
+							: 'bg-gray-100 text-gray-900'} rounded-lg px-4 py-3">
+							<div class="text-sm font-medium mb-1">
+								{message.type === 'user' ? 'You' : 'VC Partner'}
+							</div>
+							<div class="whitespace-pre-wrap">{message.content}</div>
+						</div>
+					</div>
+				{/each}
+
+				{#if isGeneratingMemo}
+					<div class="flex justify-start">
+						<div class="bg-gray-100 text-gray-900 rounded-lg px-4 py-3">
+							<div class="text-sm font-medium mb-1">VC Partner</div>
+							<div class="flex items-center space-x-2">
+								<div class="animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-600"></div>
+								<span>Generating your startup memo...</span>
+							</div>
+						</div>
+					</div>
+				{/if}
+			</div>
+
+			<!-- Input Area -->
+			{#if !isComplete}
+				<div class="border-t bg-gray-50 p-6">
+					<div class="flex flex-col space-y-4">
+						<!-- Text Input -->
+						<div class="flex space-x-3">
+							<textarea
+								bind:value={userInput}
+								onkeydown={handleKeydown}
+								placeholder="Type your answer here..."
+								class="flex-1 border border-gray-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none"
+								rows="3"
+							></textarea>
+							<Button onclick={sendMessage} disabled={!userInput.trim()}>
+								{#snippet children()}Send{/snippet}
+							</Button>
+						</div>
+
+						<!-- Action Buttons -->
+						<div class="flex space-x-3">
+							<Button variant="outline" onclick={handleDontKnow}>
+								{#snippet children()}I Don't Know{/snippet}
+							</Button>
+							<Button variant="outline" onclick={handleHelpWithResearch}>
+								{#snippet children()}Help with Research{/snippet}
+							</Button>
+						</div>
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Generated Memo Display -->
+		{#if generatedMemo}
+			<div class="mt-8 bg-white rounded-xl shadow-lg overflow-hidden">
+				<div class="bg-green-600 px-6 py-4">
+					<h2 class="text-2xl font-bold text-white">Generated Startup Memo</h2>
+					<p class="text-green-100 mt-1">Professional investment evaluation based on your session</p>
+				</div>
+				<div class="p-6">
+					<div class="prose max-w-none">
+						<pre class="whitespace-pre-wrap font-sans text-gray-900 leading-relaxed">{generatedMemo}</pre>
+					</div>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>


### PR DESCRIPTION
The VC validation page received several structural and styling updates.

*   The main navigation in `src/routes/ layout.svelte` was made `fixed` to the top of the screen using `fixed top-0 left-0 right-0 z-50` classes, with `pt-16` added to the main content to prevent overlap.
*   In `src/routes/validation/ page.svelte`:
    *   The "VC Validation Session" page header was removed for a more compact layout.
    *   The sidebar toggle (hamburger menu) was moved into the main chat/memo header, adapting its color based on the active mode (purple for chat, green for memo).
    *   The progress bar was integrated directly into the chat window's header, only visible during active chat sessions.
    *   The main content area's height was optimized using `h-[calc(100vh-8rem)]` to fit within typical screen dimensions, ensuring vertical visibility on larger screens.
    *   Memo title extraction logic was refined for more appropriate historical memo titles.
*   Tailwind CSS compatibility issues were resolved by replacing unavailable `text-3xl` and `prose-lg` utility classes with direct CSS properties for markdown rendering.
*   The `marked` library and its types were installed (`marked`, `@types/marked`) to enable markdown-to-HTML conversion for the generated memos.
*   A `.env.example` file was created to guide API key configuration.